### PR TITLE
fix soloader error

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,3 +19,4 @@
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.bundle.enableUncompressedNativeLibs=false


### PR DESCRIPTION
If we want to enable Hermes we need to activate a flag for now until react-native team fixes a bug related to native libs compression. Refer to: https://github.com/facebook/react-native/issues/23764#issuecomment-558139662

We need to remove the flag when fixed

Our stack strace is the same
```
com.facebook.soloader.SoLoader.doLoadLibraryBySoName (SoLoader.java:738)
com.facebook.soloader.SoLoader.loadLibraryBySoName (SoLoader.java:591)
com.facebook.soloader.SoLoader.loadLibrary (SoLoader.java:529)
com.facebook.soloader.SoLoader.loadLibrary (SoLoader.java:484)
com.facebook.hermes.reactexecutor.HermesExecutor.<clinit> (HermesExecutor.java:20)
com.facebook.hermes.reactexecutor.HermesExecutorFactory.create (HermesExecutorFactory.java:27)
com.facebook.react.ReactInstanceManager$5.run (ReactInstanceManager.java:952)
java.lang.Thread.run (Thread.java:818)
```